### PR TITLE
chore: update devnet configuration

### DIFF
--- a/src/components/dashboard/DetailView.tsx
+++ b/src/components/dashboard/DetailView.tsx
@@ -425,6 +425,7 @@ const FilesTab = ({ nftFile, loader }: FilesTabProps) => (
 );
 
 const MetricsTab = ({ model, loader }: MetricsTabProps) => {
+  const { infraProviders } = useAuth();
   const [metricsData, setMetricsData] = useState<{
     params: Record<string, string>;
     metrics: Record<string, string>;
@@ -441,10 +442,20 @@ const MetricsTab = ({ model, loader }: MetricsTabProps) => {
         return;
       }
 
+      // Get metrics fetch endpoint from infraProviders
+      const metricsFetchUrl = infraProviders?.[0]?.providers?.[0]?.endpoints?.mlflow?.metrics_fetch;
+
+      if (!metricsFetchUrl) {
+        console.error("MLFlow metrics_fetch endpoint not found in provider configuration");
+        toast.error("Metrics endpoint not configured");
+        setLoadingMetrics(false);
+        return;
+      }
+
       try {
         setLoadingMetrics(true);
-        const response = await END_POINTS.get_model_metadata(model.nft);
-        
+        const response = await axios.get(`${metricsFetchUrl}/${model.nft}`);
+
         if (response?.data) {
           setMetricsData({
             params: response.data.params || {},
@@ -461,7 +472,7 @@ const MetricsTab = ({ model, loader }: MetricsTabProps) => {
     };
 
     fetchMetrics();
-  }, [model?.nft]);
+  }, [model?.nft, infraProviders]);
 
   const downloadMetrics = async () => {
     if (!model?.nft) {
@@ -469,23 +480,34 @@ const MetricsTab = ({ model, loader }: MetricsTabProps) => {
       return;
     }
 
+    // Get metrics download endpoint from infraProviders
+    const metricsDownloadUrl = infraProviders?.[0]?.providers?.[0]?.endpoints?.mlflow?.metrics_download;
+
+    if (!metricsDownloadUrl) {
+      console.error("MLFlow metrics_download endpoint not found in provider configuration");
+      toast.error("Metrics download endpoint not configured");
+      return;
+    }
+
     try {
-      const response = await END_POINTS.download_model_metadata(model.nft);
-      
+      const response = await axios.get(`${metricsDownloadUrl}/${model.nft}`, {
+        responseType: 'blob'
+      });
+
       if (response?.data) {
         // Create blob from response
         const blob = new Blob([response.data], { type: 'application/json' });
         const url = URL.createObjectURL(blob);
-        
+
         const link = document.createElement('a');
         link.href = url;
         link.download = `${model?.metadata?.name || 'model'}_metrics_and_params.json`;
-        
+
         document.body.appendChild(link);
         link.click();
         document.body.removeChild(link);
         URL.revokeObjectURL(url);
-        
+
         toast.success("Metrics and parameters downloaded successfully!");
       } else {
         toast.error("No data received from server");

--- a/src/components/dashboard/ModelUploadView.tsx
+++ b/src/components/dashboard/ModelUploadView.tsx
@@ -660,15 +660,21 @@ export function ModelUploadView({ primaryColor = getNetworkColor(), compId }: Mo
       // MLflow metadata only (no model file)
       const formDatas = new FormData();
       fname = `${parseInt(Date.now().toString())}_${formData.metadataFiles[0]?.name}`;
-      
+
       const metadataFile = formData.metadataFiles[0];
       formDatas.append('modelMetadata', metadataFile);
-      
+
       formDatas.append('assetName', fname);
       formDatas.append('assetType', 'model');
+
+      // Create a placeholder empty file to satisfy API requirement
+      const placeholderBlob = new Blob([''], { type: 'application/octet-stream' });
+      const placeholderFile = new File([placeholderBlob], fname, { type: 'application/octet-stream' });
+      formDatas.append('assetFile', placeholderFile);
+
       setUploading(true)
       setUploadModelLoading(true)
-      
+
       const r1 = await END_POINTS.upload_obj(selectProvider?.endpoints?.upload, formDatas)
       if (!r1?.status) {
         toast.error("Error uploading MLflow metadata. Please try again.");

--- a/src/config/network.ts
+++ b/src/config/network.ts
@@ -156,7 +156,11 @@ const CONTRACT_ADDRESSES: ContractAddresses = {
     ? "QmS5DogBfk96voS54hhE4KemToGRWgGC6Fbk5cZboTNh3m"
     : "QmVScNzdPRuN2r7DYwcnr3PVFB4s6TPWv5o9iVWsuqyPeW",
   
-  FT_DENOM_CREATOR: "bafybmifzar4metqgkm4ivtnvabmiouyi32y2x2ikpi5h4tflrfug2ghi5q",
+  FT_DENOM_CREATOR: isMainnet 
+    ? "bafybmifzar4metqgkm4ivtnvabmiouyi32y2x2ikpi5h4tflrfug2ghi5q" 
+    : isTestnet 
+    ? "bafybmifzar4metqgkm4ivtnvabmiouyi32y2x2ikpi5h4tflrfug2ghi5q"
+    : "bafybmie3sriw6nnro5nmhgwembm7p4gynfvgkpghjoa23wkarqecvhvudi",
   
   FT_DENOM: "TRIE",
   
@@ -182,7 +186,7 @@ const API_ENDPOINTS: ApiEndpoints = {
   
   faucet: isMainnet ? "" : 
           isTestnet ? "https://trie-faucet-api.trie.network" :
-          "http://dev-faucet-api.trie.network:8443",
+          "https://dev-faucet-api.trie.network:8443",
   
   metrics: isMainnet 
     ? "https://mainnet.xellwallet.com:8449/" 

--- a/src/utils/providers.ts
+++ b/src/utils/providers.ts
@@ -15,7 +15,12 @@ export interface InfraProvider {
   endpoints?: {
     inference?: string;
     download?: string;
-    [key: string]: string | undefined;
+    upload?: string;
+    mlflow?: {
+      metrics_fetch?: string;
+      metrics_download?: string;
+    };
+    [key: string]: string | { metrics_fetch?: string; metrics_download?: string } | undefined;
   };
 }
 


### PR DESCRIPTION
chore: update devnet configuration

- Add separate FT_DENOM_CREATOR for devnet: bafybmie3sriw6nnro5nmhgwembm7p4gynfvgkpghjoa23wkarqecvhvudi
- Update devnet faucet URL to use HTTPS instead of HTTP

feat: use dynamic MLFlow endpoints from provider config

- Update MetricsTab to fetch metrics from provider's mlflow endpoints
- Add TypeScript support for nested mlflow object in InfraProvider
- Follow existing pattern for upload/download endpoints